### PR TITLE
fix: 새로운 구독 post 시 response count 이름 fac_count으로 변경

### DIFF
--- a/src/main/java/ChariO/GiBoo/api/FacApiController.java
+++ b/src/main/java/ChariO/GiBoo/api/FacApiController.java
@@ -66,4 +66,6 @@ public class FacApiController {
                 .collect(Collectors.toList());
         return new DetailFacResponse(new FacDto(facility), collect);
     }
+
+
 }

--- a/src/main/java/ChariO/GiBoo/dto/SubscribeDtos.java
+++ b/src/main/java/ChariO/GiBoo/dto/SubscribeDtos.java
@@ -68,11 +68,11 @@ public class SubscribeDtos {
 
     @Data
     public static class subscribePostDeleteResponse {
-        Long count;
+        Long fac_count;
         String status;
 
         public subscribePostDeleteResponse(Long cnt, String status){
-            this.count = cnt;
+            this.fac_count = cnt;
             this.status = status;
         }
     }


### PR DESCRIPTION
## json response 필드 이름 수정
- 앱 측에서 얘기한 대로 좋아요 개수를 count -> fac_count로 변경했습니다!