### PR TITLE
Content

### DIFF
--- a/src/main/java/ChariO/GiBoo/api/ConApiController.java
+++ b/src/main/java/ChariO/GiBoo/api/ConApiController.java
@@ -1,34 +1,33 @@
 package ChariO.GiBoo.api;
 
 import ChariO.GiBoo.domain.Contents;
-import lombok.Data;
+import ChariO.GiBoo.service.ConService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Date;
+import static ChariO.GiBoo.dto.ConDtos.*;
 
 @RestController
 @RequiredArgsConstructor
 public class ConApiController {
 
+    private final ConService conService;
 
-    @Data
-    static class ContentDto{
-        private String c_title;
-        private String c_contents;
-        private String c_image;
-        private String c_url;
-
-        @DateTimeFormat(pattern = "MM/dd/yyyy")
-        private Date c_pub_date;
-
-        public ContentDto(Contents content){
-            this.c_title = content.getC_title();
-            this.c_contents = content.getC_contents();
-            this.c_image = content.getC_image();
-            this.c_pub_date = content.getC_pub_date();
-            this.c_url = content.getC_url();
-        }
+    @Operation(summary = "컨텐츠 단일 조회", description = "컨텐츠의 title, body, image_url, url, pub_date 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
+            @ApiResponse(responseCode = "404", description = "NOT FOUND"),
+            @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
+    })
+    @GetMapping(value = "/api/content/{id}/", produces = "application/json;charset=UTF-8")
+    public ContentDto oneContent(@PathVariable("id") Long con_id) {
+        Contents content = conService.findOne(con_id);
+        return new ContentDto(content);
     }
 }

--- a/src/main/java/ChariO/GiBoo/dto/ConDtos.java
+++ b/src/main/java/ChariO/GiBoo/dto/ConDtos.java
@@ -10,6 +10,7 @@ public class ConDtos {
 
     @Data
     public static class ContentDto {
+        private Long f_id;
         private Long c_id;
         private String title;
         private String body;
@@ -20,6 +21,7 @@ public class ConDtos {
         private Date pub_date;
 
         public ContentDto(Contents content) {
+            this.f_id = content.getFacility().getId();
             this.c_id = content.getId();
             this.title = content.getC_title();
             this.body = content.getC_contents();

--- a/src/main/java/ChariO/GiBoo/dto/ConDtos.java
+++ b/src/main/java/ChariO/GiBoo/dto/ConDtos.java
@@ -1,0 +1,31 @@
+package ChariO.GiBoo.dto;
+
+import ChariO.GiBoo.domain.Contents;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.util.Date;
+
+public class ConDtos {
+
+    @Data
+    public static class ContentDto {
+        private Long c_id;
+        private String title;
+        private String body;
+        private String image;
+        private String url;
+
+        @DateTimeFormat(pattern = "MM/dd/yyyy")
+        private Date pub_date;
+
+        public ContentDto(Contents content) {
+            this.c_id = content.getId();
+            this.title = content.getC_title();
+            this.body = content.getC_contents();
+            this.image = content.getC_image();
+            this.pub_date = content.getC_pub_date();
+            this.url = content.getC_url();
+        }
+    }
+}

--- a/src/main/java/ChariO/GiBoo/repository/ConRepository.java
+++ b/src/main/java/ChariO/GiBoo/repository/ConRepository.java
@@ -15,7 +15,11 @@ public class ConRepository {
     private final FacRepository facRepository;
 
     public Contents findOne(Long id){
-        return em.find(Contents.class, id);
+        return em.createQuery("select c from Contents c " +
+                "join fetch c.facility "+
+                "where c.id = :id", Contents.class)
+                .setParameter("id", id)
+                .getSingleResult();
     }
 
     public List<Contents> findByFac(Long id){

--- a/src/main/java/ChariO/GiBoo/repository/ConRepository.java
+++ b/src/main/java/ChariO/GiBoo/repository/ConRepository.java
@@ -15,8 +15,7 @@ public class ConRepository {
     private final FacRepository facRepository;
 
     public Contents findOne(Long id){
-        Contents content = em.find(Contents.class, id);
-        return content;
+        return em.find(Contents.class, id);
     }
 
     public List<Contents> findByFac(Long id){

--- a/src/main/java/ChariO/GiBoo/service/ConService.java
+++ b/src/main/java/ChariO/GiBoo/service/ConService.java
@@ -15,4 +15,8 @@ public class ConService {
     public List<Contents> findByFac(Long id){
         return contentRepository.findByFac(id);
     }
+
+    public Contents findOne(Long con_id){
+        return contentRepository.findOne(con_id);
+    }
 }


### PR DESCRIPTION
## 컨텐츠 단일 조회 api 추가
- 컨텐츠 상세 페이지에서 필요한 컨텐츠 단일 조회 api 개발
- 컨텐츠 페이지 조회에서 f_id가 필요할 수 있을 것 같아 api 스펙에 추가
- 컨텐츠 조회는 로그인이 되지 않은 상태에서도 조회할 수 있도록 header을 넣지 않아도 되도록 구성