### PR TITLE
Feat: 신규가입시 구독 기관 추가하는 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,5 +55,5 @@ tasks.named('test') {
 bootJar {
 	archivesBaseName = 'GiBooApplication'
 	archiveFileName = 'Chario.jar'
-	archiveVersion = "1.0.3"
+	archiveVersion = "1.0.4"
 }

--- a/src/main/java/ChariO/GiBoo/api/SubApiController.java
+++ b/src/main/java/ChariO/GiBoo/api/SubApiController.java
@@ -61,6 +61,34 @@ public class SubApiController {
     }
 
     /**
+     * 신규 사용자의 구독(좋아요)기관 추가.
+     */
+    @Operation(summary = "Get subscribe list from new user", description = "신규 사용자의 구독 리스트 추가")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
+            @ApiResponse(responseCode = "404", description = "NOT FOUND"),
+            @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
+    })
+    @PostMapping(value = "/api/subscribe", produces = "application/json;charset=UTF-8")
+    public SubscribeListPostResponse subscribeListPost(@RequestHeader("Authorization") String u_uuid,
+                                                       @RequestBody SubscribeListPostRequest request){
+
+        Long u_id = userService.findByUuid(u_uuid);
+        List<Long> facList = request.getFac_id();
+
+        for(Long tmp:facList) {
+            Subscribe subscribe = new Subscribe();
+            subscribe.setUser(userService.findOne(u_id));
+            subscribe.setFacility(facService.findOne(tmp));
+            subscribeService.newSubscribe(subscribe);
+        }
+
+        String status = "정상적으로 저장 되었습니다.";
+        return new SubscribeListPostResponse(status);
+    }
+
+    /**
      * 현재 사용자가 신규 좋아요를 누름. + 해당 기관의 좋아요 개수
      */
     @Operation(summary = "user post subscribe", description = "사용자가 해당 기관을 새로 구독하는 경우")

--- a/src/main/java/ChariO/GiBoo/dto/SubscribeDtos.java
+++ b/src/main/java/ChariO/GiBoo/dto/SubscribeDtos.java
@@ -83,6 +83,21 @@ public class SubscribeDtos {
     }
 
     @Data
+    public static class SubscribeListPostRequest {
+        private List<Long> fac_id;
+    }
+
+    @Data
+    public static class SubscribeListPostResponse {
+        private String status;
+
+        public  SubscribeListPostResponse(String status){
+            this.status = status;
+        }
+    }
+
+
+    @Data
     public static class SubscribePostDeleteResponse {
         Long fac_count;
         String status;


### PR DESCRIPTION
- Build.gradle : 새로운 서버 배포하면서 버젼 변경했습니다.
- SubApi: 신규 유저 가입시 구독리스트 추가하는 창에서 필요한 API 간단한게 구현 했습니다. 다만 count의 경우 필요없다고 판단하여 제외시켰습니다.
- SubDtos: 필요한  DTO 추가하였습니다. 