### PR TITLE
feat: category 명 조회 api 개발

### DIFF
--- a/src/main/java/ChariO/GiBoo/api/CateApiController.java
+++ b/src/main/java/ChariO/GiBoo/api/CateApiController.java
@@ -1,0 +1,30 @@
+package ChariO.GiBoo.api;
+
+import ChariO.GiBoo.service.FacCateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static ChariO.GiBoo.dto.FacCateDtos.*;
+
+@RestController
+@RequiredArgsConstructor
+public class CateApiController {
+
+    private final FacCateService facCateService;
+
+    @Operation(summary = "Category만 조회", description = "카테고리의 아이디와 카테고리 이름만 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
+            @ApiResponse(responseCode = "404", description = "NOT FOUND"),
+            @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
+    })
+    @GetMapping(value = "/api/categories", produces = "application/json;charset=UTF-8")
+    public GetCateResponse categories(){
+        return new GetCateResponse(facCateService.findCateAll());
+    }
+}

--- a/src/main/java/ChariO/GiBoo/api/FacCateApiController.java
+++ b/src/main/java/ChariO/GiBoo/api/FacCateApiController.java
@@ -1,4 +1,0 @@
-package ChariO.GiBoo.api;
-
-public class FacCateApiController {
-}

--- a/src/main/java/ChariO/GiBoo/dto/FacCateDtos.java
+++ b/src/main/java/ChariO/GiBoo/dto/FacCateDtos.java
@@ -4,6 +4,9 @@ import ChariO.GiBoo.domain.Facility;
 import ChariO.GiBoo.domain.FacilityCategory;
 import lombok.Data;
 
+import java.util.List;
+
+import static ChariO.GiBoo.dto.CateDtos.*;
 import static ChariO.GiBoo.dto.FacDtos.*;
 
 public class FacCateDtos {
@@ -23,6 +26,17 @@ public class FacCateDtos {
 
         public FacByCateDto(FacilityCategory fc){
             this.facility = new FacDto(fc.getFacility());
+        }
+    }
+
+    @Data
+    public static class GetCateResponse {
+        private Long count;
+        private List<CateDto> categories;
+
+        public GetCateResponse(List<CateDto> categories) {
+            this.count = categories.stream().count();
+            this.categories = categories;
         }
     }
 }

--- a/src/main/java/ChariO/GiBoo/repository/FacCateRepository.java
+++ b/src/main/java/ChariO/GiBoo/repository/FacCateRepository.java
@@ -1,13 +1,18 @@
 package ChariO.GiBoo.repository;
 
+import ChariO.GiBoo.domain.Category;
 import ChariO.GiBoo.domain.Facility;
 import ChariO.GiBoo.domain.FacilityCategory;
+import ChariO.GiBoo.dto.CateDtos;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static ChariO.GiBoo.dto.CateDtos.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -33,5 +38,11 @@ public class FacCateRepository {
                 .setParameter("id", id)
                 .getResultList();
     }
-
+    
+    public List<CateDto> findCategoryAll(){
+        List<Category> categories = em.createQuery("select c from Category c", Category.class)
+                .getResultList();
+        List<CateDto> result = categories.stream().map(c -> new CateDto(c)).collect(Collectors.toList());
+        return result;
+    }
 }

--- a/src/main/java/ChariO/GiBoo/service/FacCateService.java
+++ b/src/main/java/ChariO/GiBoo/service/FacCateService.java
@@ -1,6 +1,7 @@
 package ChariO.GiBoo.service;
 
 import ChariO.GiBoo.domain.FacilityCategory;
+import ChariO.GiBoo.dto.CateDtos;
 import ChariO.GiBoo.repository.FacCateRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static ChariO.GiBoo.dto.CateDtos.*;
 
 @Service
 @RequiredArgsConstructor
@@ -24,5 +27,10 @@ public class FacCateService {
 
     @Transactional(readOnly = true)
     public List<FacilityCategory> findCatesByFacId(Long id) { return facCateRepository.findByFacId(id);}
+
+    @Transactional(readOnly = true)
+    public List<CateDto> findCateAll(){
+        return facCateRepository.findCategoryAll();
+    }
 
 }


### PR DESCRIPTION
## category 리스트 조회 api 개발
- 앱에서 있으면 좋다고 했던 api입니다. (근데 너무 늦었나요..?)
- api spec은 category 총 수(count)랑 categories(카테고리 id, 카테고리명 의 리스트) 로 했습니다. (전에 data로 한 번 더 감싸는 걸 별로 안 좋아했던 것 같아서 이렇게 구성했습니다.)
- api는 cate api controller로 생성했는데, dto는 기존에 있던 cateDto를, 그리고 리포지토리나 서비스는 FacCate에 추가해두었습니다. (Category만 별도로 리포지토리나 서비스를 만들 필요는 없을 것 같습니다)